### PR TITLE
chore(webpack): fix eslint-loader to exclude grammars

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,12 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
+        exclude: /(node_modules|grammars)/,
         enforce: 'pre',
-        use: 'eslint-loader',
+        loader: 'eslint-loader',
+        options: {
+          failOnError: true,
+        },
       },
       {
         test: /\.tsx?$/,


### PR DESCRIPTION
close #1 